### PR TITLE
Stuck-Timeout hinzugefügt

### DIFF
--- a/gui/vehicleSettingsPage.xml
+++ b/gui/vehicleSettingsPage.xml
@@ -28,6 +28,21 @@
 				<Text profile="fs25_settingsMultiTextOptionTitle" text="$l10n_gui_ad_followDistance"/>
 			</Bitmap>
 			<Bitmap profile="fs25_multiTextOptionContainer" onCreate="onCreateAutoDriveSettingRow">
+				<MultiTextOption profile="fs25_settingsMultiTextOption" onClick="onOptionChange" onCreate="onCreateAutoDriveSetting" name="stuckTimeout" id="stuckTimeout">
+					<Text profile="fs25_multiTextOptionTooltip"
+					      name="ignore"
+					      text="$l10n_gui_ad_stuckTimeout_tooltip"/>
+				</MultiTextOption>
+				<Text profile="fs25_settingsMultiTextOptionTitle"
+				      text="$l10n_gui_ad_stuckTimeout"/>
+			</Bitmap>
+			<Bitmap profile="fs25_multiTextOptionContainer" onCreate="onCreateAutoDriveSettingRow">
+				<BinaryOption profile="fs25_settingsBinaryOption" onClick="onOptionChange" onCreate="onCreateAutoDriveSetting" name="stuckDeactivate" id="stuckDeactivate">
+					<Text profile="fs25_multiTextOptionTooltip" name="ignore" text="$l10n_gui_ad_stuckDeactivate_tooltip"/>
+				</BinaryOption>
+				<Text profile="fs25_settingsMultiTextOptionTitle" text="$l10n_gui_ad_stuckDeactivate"/>
+			</Bitmap>
+			<Bitmap profile="fs25_multiTextOptionContainer" onCreate="onCreateAutoDriveSettingRow">
 				<MultiTextOption profile="fs25_settingsMultiTextOption" onClick="onOptionChange" onCreate="onCreateAutoDriveSetting" name="unloadFillLevel" id="unloadFillLevel">
 					<Text profile="fs25_multiTextOptionTooltip" name="ignore" text="$l10n_gui_ad_unloadFillLevel_tooltip"/>
 				</MultiTextOption>

--- a/scripts/Settings.lua
+++ b/scripts/Settings.lua
@@ -1016,6 +1016,7 @@ AutoDrive.settings.ALUnload = {
     translate = true,
     isVehicleSpecific = true
 }
+
 AutoDrive.settings.ALUnloadWaitTime = {
     values = {0, 1000, 3000, 5000, 10000, 15000, 20000, 25000, 30000, 60000, 120000, 300000, 600000},
     texts = {"0", "1s", "3s", "5s", "10s", "15s", "20s", "25s", "30s", "1min", "2min", "5min", "10min"},
@@ -1025,6 +1026,28 @@ AutoDrive.settings.ALUnloadWaitTime = {
     tooltip = "gui_ad_ALUnloadWaitTime_tooltip",
     translate = false,
     isVehicleSpecific = true
+}
+
+AutoDrive.settings.stuckTimeout = {
+    values = {0, 5000, 10000, 15000, 20000, 25000, 30000, 60000, 120000, 300000, 600000},
+    texts = {"0", "5s", "10s", "15s", "20s", "25s", "30s", "1min", "2min", "5min", "10min"},
+    default = 1,
+    current = 1,
+    text = "gui_ad_stuckTimeout",
+    tooltip = "gui_ad_stuckTimeout_tooltip",
+    translate = false,
+    isVehicleSpecific = true,
+}
+
+AutoDrive.settings.stuckDeactivate = {
+    values = {false, true},
+    texts = {"gui_ad_no", "gui_ad_yes"},
+    default = 1,
+    current = 1,
+    text = "gui_ad_stuckDeactivate",
+    tooltip = "gui_ad_stuckDeactivate_tooltip",
+    translate = true,
+    isVehicleSpecific = true,
 }
 
 AutoDrive.settings.playSounds = {

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -314,6 +314,10 @@
 		<text name="gui_ad_debugChannelAll"							text="Alles" />
 		<text name="gui_ad_notificationHistoryTitle"					text="Benachrichtigungen" />
 		<text name="gui_ad_colorSettingsTitle"							text="Farbzuweisungen" />
+		<text name="gui_ad_stuckTimeout" 								text="Stuck-Timeout"/>
+		<text name="gui_ad_stuckTimeout_tooltip" 					text="Nach dieser Zeit ohne Vorwärtsbewegung Warnung ausgeben (0 = nie)"/>
+		<text name="gui_ad_stuckDeactivate" 								text="Stuck AutoDrive-Deaktivierung"/>
+		<text name="gui_ad_stuckDeactivate_tooltip" 					text="Wenn Stuck-Timeout an und abgelaufen ist, AutoDrive für Fahrzeug deaktivieren."/>
 		<!-- Please keep the numbers in the translation texts - they are used to sort / group the entries in the list -->
 		<text name="ad_color_singleConnection"							text="01 Linie Hauptstrecke eine Richtung" />
 		<text name="ad_color_dualConnection"							text="02 Linie Hauptstrecke zwei Richtungen" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -314,6 +314,10 @@
 		<text name="gui_ad_debugChannelAll"							text="Everything" />
 		<text name="gui_ad_notificationHistoryTitle"					text="Notifications" />
 		<text name="gui_ad_colorSettingsTitle"							text="Color Assignments" />
+		<text name="gui_ad_stuckTimeout" 								text="Stuck-Timeout"/>
+		<text name="gui_ad_stuckTimeout_tooltip" 					text="Send warning message after vehicle is stuck for specified time (0 = never)"/>
+		<text name="gui_ad_stuckDeactivate" 								text="Stuck AutoDrive Deactivation"/>
+		<text name="gui_ad_stuckDeactivate_tooltip" 					text="If Stuck-Timeout is on and expired, AutoDrive will be deactivated for the vehicle."/>
 		<!-- Please keep the numbers in the translation texts - they are used to sort / group the entries in the list -->
 		<text name="ad_color_singleConnection"							text="01 line of single-way connection" />
 		<text name="ad_color_dualConnection"							text="02 line of dual-way connection" />


### PR DESCRIPTION
Einstellbarere Stuck-Timeout, wenn ein Fahrzeug für eingestellte Zeit sich nicht bewegt wird eine Warnung ausgegeben.
Optional noch die Einstellung dass AD dann ausgeschaltet wird 
-> Sinnvoll wenn mehrere Fahrzeuge den selben Parkplatz haben und in einer Reihe parken