### PR TITLE
Increase minimum front object sensor length from 0.2m to 2m

### DIFF
--- a/scripts/Sensors/VirtualSensors.lua
+++ b/scripts/Sensors/VirtualSensors.lua
@@ -44,7 +44,7 @@ function ADSensor:addSensorsToVehicle(vehicle)
     vehicle.ad.sensors = {}
     local sensorParameters = {}
     sensorParameters.dynamicLength = true
-    sensorParameters.minDynamicLength = 0.2
+    sensorParameters.minDynamicLength = 2
     sensorParameters.minDynamicLengthForVehicles = 2
     sensorParameters.position = ADSensor.POS_FRONT
     sensorParameters.width = vehicle.size.width * 0.75


### PR DESCRIPTION
At low speeds, the dynamic lookahead box of `frontSensorDynamicShort` for static objects shrinks down to `minDynamicLength = 0.2` (`VirtualSensors.lua`), so thin obstacles like lamp posts are effectively only detected on contact. Vehicles already use a 2 m minimum (`minDynamicLengthForVehicles`).

This applies the same 2 m minimum to static objects, so obstacles are detected early enough to stop in front of them even at crawl speed.

One-line change, no behavior change at normal driving speeds (there the speed-based lookahead is larger anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)