### PR TITLE
Add strict pathfinding setting for looping courses

### DIFF
--- a/scripts/Modules/DrivePathModule.lua
+++ b/scripts/Modules/DrivePathModule.lua
@@ -44,9 +44,12 @@ function ADDrivePathModule:reset(retainLastUsedWaypoint)
     self.vehicle:setTurnLightState(Lights.TURNLIGHT_OFF)
     self.distanceToTarget = math.huge
     self.speedLimit = 0
-    -- skip resetting last used waypoint to resume looping courses from prior destination
-    if not retainLastUsedWaypoint then
+    -- skip resetting last used waypoint to resume looping courses or refuel/repair tasks from prior destination
+    if retainLastUsedWaypoint then
+        self.isResumingFromLastWayPoint = true
+    else
         self.lastUsedWayPoint = nil
+        self.isResumingFromLastWayPoint = false
     end
     -- increase steering speed
     if self.vehicle.spec_aiJobVehicle ~= nil then
@@ -56,7 +59,7 @@ function ADDrivePathModule:reset(retainLastUsedWaypoint)
 end
 
 function ADDrivePathModule:setPathTo(wayPointId)
-    self:reset(self.atTarget)
+    self:reset(self.atTarget or self.isResumingFromLastWayPoint)
     self.wayPoints = ADGraphManager:getPathTo(self.vehicle, wayPointId, self.lastUsedWayPoint)
     local destination = ADGraphManager:getMapMarkerByWayPointId(self:getLastWayPointId())
     self.vehicle.ad.stateModule:setCurrentDestination(destination)

--- a/scripts/Specialization.lua
+++ b/scripts/Specialization.lua
@@ -1183,13 +1183,13 @@ function AutoDrive:startAutoDrive()
     end
 end
 
-function AutoDrive:stopAutoDrive()
+function AutoDrive:stopAutoDrive(retainLastUsedWaypoint)
 
     if self.isServer then
         ADScheduler:removePathfinderVehicle(self)
 
         if self.ad.stateModule:isActive() then
-            self.ad.drivePathModule:reset()
+            self.ad.drivePathModule:reset(retainLastUsedWaypoint)
             self.ad.specialDrivingModule:reset()
             self.ad.trailerModule:reset()
 

--- a/scripts/Tasks/RefuelTask.lua
+++ b/scripts/Tasks/RefuelTask.lua
@@ -95,7 +95,7 @@ function RefuelTask:finished()
     self.vehicle.ad.onRouteToRefuel = #AutoDrive.getRequiredRefuels(self.vehicle, self.vehicle.ad.onRouteToRefuel) > 0
     self.refuelTrigger = nil
     self.wasRefuelling = false
-    self.vehicle:stopAutoDrive()
+    self.vehicle:stopAutoDrive(true) -- stop AD, but retain last used waypoint so we can resume from it
     self.vehicle.ad.stateModule:getCurrentMode():start()
     self.vehicle.ad.taskModule:setCurrentTaskFinished(ADTaskModule.DONT_PROPAGATE)
 end

--- a/scripts/Tasks/RepairTask.lua
+++ b/scripts/Tasks/RepairTask.lua
@@ -88,7 +88,7 @@ end
 function RepairTask:finished()    
     self.vehicle.ad.onRouteToRepair = false
 
-    self.vehicle:stopAutoDrive()
+    self.vehicle:stopAutoDrive(true) -- stop AD, but retain last used waypoint so we can resume from it
     self.vehicle.ad.stateModule:getCurrentMode():start()
     self.vehicle.ad.taskModule:setCurrentTaskFinished(ADTaskModule.DONT_PROPAGATE)
 end


### PR DESCRIPTION
Adds a new setting "strictPathResume" to resume looping courses from the destination of the previous leg rather than searching for a new start point. This new setting is off by default for backwards compatibility. I didn't see any reason to make it per-vehicle, so right now it's a global setting.

This addresses the inconsistent/unexpected behavior mentioned in https://github.com/Stephan-S/FS25_AutoDrive/issues/558

I'm marking this PR as a draft to call attention to the large diff in `translation_tr.xml`. It looks like the `sync_translations` script is making some whitespace changes to older sections that weren't previously committed, and I'm not sure if I should use the cleaned up automatically generated version or hand-edit to preserve the original whitespace.